### PR TITLE
Pequenas modificações para usar no deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Arquivos do sistema
+.git
+.gitignore
+.dockerignore
+
+# Dependências
+venv/
+env/
+.venv/
+
+# Arquivos de log
+*.log
+
+# Arquivos de cache
+__pycache__/
+*.pyc
+
+# Arquivos de teste
+test/
+tests/
+
+# Arquivos de documentação
+docs/
+
+# Arquivos de build
+build/
+dist/
+*.egg-info/
+
+# Arquivos de configuração
+.env
+.flaskenv
+
+# Arquivos grandes desnecessários
+*.tgz
+*.zip
+*.tar.gz
+
+# Outros arquivos desnecessários 
+README.md
+LICENSE

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+MYSQL_ROOT_PASSWORD=sua_senha_root
+MYSQL_DATABASE=nome_do_banco_de_dados
+MYSQL_USER=usuario_do_banco  
+MYSQL_PASSWORD=senha_do_usuario
+MYSQL_HOST=servidor_do_mysql
+MYSQL_PORT=porta_do_mysql
+APP_PORT=porta_da_aplicacao_django
+SECRET_KEY=sua_chave_secreta_aleatoria
+
+GITHUB_CLIENT_ID=seu_client_id_do_github
+GITHUB_CLIENT_SECRET=seu_client_secret_do_github
+
+COMMIT_MULTIPLIER=1
+LINES_MULTIPLIER=0.001
+ISSUES_MULTIPLIER=1
+PULLS_MULTIPLIER=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,16 @@ version: '3'
 
 services:
   web:
-    build: .
+    image: wilsonsantosphx/rinhadev_mabel:latest
     command: >
-          sh -c " pip install -r requirements.txt &&
-          python manage.py makemigrations &&
-          python manage.py migrate &&
-          python manage.py runserver 0.0.0.0:8000"
+          sh -c "
+                python manage.py makemigrations && 
+                python manage.py migrate &&
+                python manage.py runserver 0.0.0.0:8000"
     volumes:
       - .:/app
     ports:
-      - "8000:8000"
+      - "${APP_PORT}:8000"
     depends_on:
       - db
   db:
@@ -25,7 +25,7 @@ services:
     volumes:
       - dbdata:/var/lib/mysql
     ports:
-      - "3306:3306"
+      - "${MYSQL_PORT}:3306"
 
 volumes:
   dbdata:

--- a/setup/settings.py
+++ b/setup/settings.py
@@ -43,6 +43,8 @@ MYSQL_ROOT_PASSWORD = os.getenv("MYSQL_ROOT_PASSWORD")
 MYSQL_DATABASE = os.getenv("MYSQL_DATABASE")
 MYSQL_USER = os.getenv("MYSQL_USER")
 MYSQL_PASSWORD = os.getenv("MYSQL_PASSWORD")
+MYSQL_HOST = os.getenv("MYSQL_HOST")
+MYSQL_PORT = os.getenv("MYSQL_PORT")
 
 
 # Quick-start development settings - unsuitable for production
@@ -111,8 +113,8 @@ DATABASES = {
         "NAME": MYSQL_DATABASE,
         "USER": MYSQL_USER,
         "PASSWORD": MYSQL_PASSWORD,  # Senha do MySQL
-        "HOST": "db",  # Nome do serviço no Docker Compose
-        "PORT": "3306",
+        "HOST": MYSQL_HOST,  # Nome do serviço no Docker Compose
+        "PORT": MYSQL_PORT,
     }
 }
 


### PR DESCRIPTION
.env de exemplo
dockerignore
Remoção da migration do compose
Altera o compose para pegar de uma imagem nomeada e tagueada
Host do banco de dados, porta do mysql e do app configuradas via env para facilitar no deploy